### PR TITLE
TT-1572: Clarify "Signature verification failed"

### DIFF
--- a/source/pages/msa/msaUse.rst
+++ b/source/pages/msa/msaUse.rst
@@ -268,7 +268,7 @@ You can now run :ref:`SAML compliance tests between the hub and your MSA <samlCT
 
 **Signature verification failed**  
 
-When starting the MSA, you may receive an error message with the phrase ‘signature verification failed’. This is expected behaviour.
+When starting the MSA, you may receive an error message with the phrase ‘signature verification failed’. This is expected behaviour and is logged from a third-party library. 
 
 The Verify hub metadata contains multiple signing certificates, but only one private key is in use at a time. The metadata refreshes automatically approximately every 10 minutes. 
 


### PR DESCRIPTION
Some users reporting 'signature verification failed' errors with MSA. Expected behaviour, but not documented. Added explanation and removed rogue typo in paragraph above. 

Author: @J-Lambo with input from @richardTowers and @willp-bl