### PR TITLE
BAU: Clarifying integration requirements for connecting services

### DIFF
--- a/source/pages/env/envRequestform.rst
+++ b/source/pages/env/envRequestform.rst
@@ -46,7 +46,7 @@ If applicable to your service, you’ll need to provide:
 - `Cycle 3 attributes <http://alphagov.github.io/rp-onboarding-tech-docs/pages/ms/msWorks.html?highlight=cycle#ms-mc3>`_, for example driving licence or passport number
 - `‘New User’ account <http://alphagov.github.io/rp-onboarding-tech-docs/pages/ms/msWorks.html?highlight=cycle#ms-mc3>`_ attributes, for example first name, middle name, surname, date of birth, current address
 
-For Integration environments only, you’ll also need to provide the following in addition to the above:
+For Integration environments, you’ll also need to provide the following in addition to the above:
 
 - an IP address for your Matching Service Adapter and test device browser
 - a username and 8-character password (to manage the test user data)


### PR DESCRIPTION
There was some confusion over the requirements for Integration. Specifically,
an RP wanted to onboard/connect using an IP before having a domain available.
If skipping over the documentation it can be misleading as the last section on
the page could be interpreted as the only requirements for integration. This
commit adds some language to clarify this. Following our move to the *-a
environments in AWS and once HIDS monitoring is in place this requirement for
an IP address will be unnecessary.

solo: @jstandring-gds