### PR TITLE
Rephrased advice for matching strategy

### DIFF
--- a/source/pages/matching/matchingserviceadapter.rst
+++ b/source/pages/matching/matchingserviceadapter.rst
@@ -270,7 +270,7 @@ In the field ``europeanIdentity``
 11. Configure according to the needs of your service:
 
   If your service needs to consume European identities, set ``enabled: true``.
-  You also need to configure the URLs for the environments want to use, for example integration or production. Enabling your service to consume European identities also implies that it will be using :ref:`the universal JSON matching schema<JSONschema>`. The schema will apply to datasets from both European countries, as well as GOV.UK Verify identity providers.
+  You also need to configure the URLs for the environments you want to use, for example integration or production. Enabling your service to consume European identities also implies that it will be using :ref:`the universal JSON matching schema<JSONschema>`. The schema will apply to datasets from both European countries, as well as GOV.UK Verify identity providers.
 
   If if you need to disable European identities, set ``enabled: false`` in this section. This setting also implies your MSA will be using :ref:`the legacy JSON matching schema<legacyJSONschema>`.
 

--- a/source/pages/matching/matchingstrategy.rst
+++ b/source/pages/matching/matchingstrategy.rst
@@ -143,20 +143,22 @@ In practice, this means European citizens will be able to use their national onl
 
 If your service needs to be able to process EU identities, you need to :ref:`configure your MSA<msa_adapt_YAML>` to do this.
 
-European identities you receive from the GOV.UK Verify Hub will always be in the format of the :ref:`universal JSON matching schema<JSONschema>`, and will only include:
+Once configured, both European identities and GOV.UK Verify identities you receive will always be in the format of the :ref:`universal JSON matching schema<JSONschema>`.
+
+European identities will only include verified attributes:
 
 - first name, ``firstName``
 - surname, ``surnames``
 - date of birth, ``dateOfBirth``
 - a personal identifier or equivalent from the EU member state (the equivalent of the PID),
 
-These are all verified attributes. The data from European citizens will not include any historical attributes or unverified attributes.
+The data from European citizens will not include any historical attributes or unverified attributes.
 
-For names using non-Latin characters, both the non-Latin as well as a Latin equivalent will appear in the JSON received by your matching service. Because European identities will not contain middle names, only ``firstName`` and ``surnames`` may contain a ``nonLatinScriptValue`` property, where applicable
+For names using non-Latin characters, both the non-Latin as well as a Latin equivalent will appear in the JSON received by your matching service. Because European identities will not contain middle names, only ``firstName`` and ``surnames`` may contain a ``nonLatinScriptValue`` property, where applicable.
 
 The UK uses addresses as an extra attribute to establish identity and help with matching. Other countries can use a personal identification number or similar. Both approaches meet identity assurance standards.
 
-Keep in mind that EU identities don't include addresses. If your service needs to be able to process EU identities, make sure your matching strategy is not based on addresses.
+If you :ref:`cofigure your MSA to accept EU identities<msaeidas>`, make sure your matching strategy does not rely on receiving an ``addresses`` attribute for all identities. EU identities won't have an ``addresses`` attribute. GOV.UK Verify identities will have at least one verified ``addresses`` attribute that you can use in your matching strategy.
 
 
 **Unverified attributes**


### PR DESCRIPTION
In `matchingstrategy.rst` under *European identities and eIDAS*
 - the matching strategy should not expect an `addresses` attribute
 - EU identities will never have an `addresses` attribute
 - Verify identities will have at least one verified
`addresses` attribute which can be used for matching

Corrected typos in
 - matchingserviceadapter.rst
 - matchingstrategy.rst