### PR TITLE
Add verify-eidas-metadata-aggregator to the list of open components.

### DIFF
--- a/source/pages/open/opencomponents.rst
+++ b/source/pages/open/opencomponents.rst
@@ -46,6 +46,8 @@ For open use
 +---------------------------------------+--------------------------------------------------------------------------------------------------------------------------------+
 | verify-test-rp_                       | A stub Relying Party used when testing the GOV.UK Verify Hub.                                                                  |
 +---------------------------------------+--------------------------------------------------------------------------------------------------------------------------------+
+| verify-eidas-metadata-aggregator_     | An application that first retrieves and validates metadata from EU Countrires then copies the valid metadata to AWS S3 bucket  |
++---------------------------------------+--------------------------------------------------------------------------------------------------------------------------------+
 
 .. _passport-verify-stub-relying-party: https://github.com/alphagov/passport-verify-stub-relying-party
 .. _passport-verify: https://github.com/alphagov/passport-verify
@@ -56,6 +58,7 @@ For open use
 .. _verify-hub: https://github.com/alphagov/verify-hub
 .. _verify-stub-idp: https://github.com/alphagov/verify-stub-idp
 .. _verify-test-rp: https://github.com/alphagov/verify-test-rp
+.. _verify-eidas-metadata-aggregator: https://github.com/alphagov/verify-eidas-metadata-aggregator
 
 **Libraries**
 

--- a/source/pages/open/opencomponents.rst
+++ b/source/pages/open/opencomponents.rst
@@ -42,11 +42,11 @@ For open use
 +---------------------------------------+--------------------------------------------------------------------------------------------------------------------------------+
 | verify-hub_                           | A system of microservices to manage interactions between users, government services, identity providers, and matching services |
 +---------------------------------------+--------------------------------------------------------------------------------------------------------------------------------+
-| verify-stub-idp_                      | A stub Identity Provider and stub EU Country used for testing GOV.UK Verify and eIDAS integration.                             |
+| verify-stub-idp_                      | A stub Identity Provider and stub EU country used for testing GOV.UK Verify and eIDAS integration                             |
 +---------------------------------------+--------------------------------------------------------------------------------------------------------------------------------+
-| verify-test-rp_                       | A stub Relying Party used when testing the GOV.UK Verify Hub.                                                                  |
+| verify-test-rp_                       | A stub Relying Party used when testing the GOV.UK Verify Hub                                                                 |
 +---------------------------------------+--------------------------------------------------------------------------------------------------------------------------------+
-| verify-eidas-metadata-aggregator_     | An application that first retrieves and validates metadata from EU Countrires then copies the valid metadata to AWS S3 bucket  |
+| verify-eidas-metadata-aggregator_     | An application that retrieves and validates metadata from EU countries and then copies the valid metadata to an AWS S3 bucket |
 +---------------------------------------+--------------------------------------------------------------------------------------------------------------------------------+
 
 .. _passport-verify-stub-relying-party: https://github.com/alphagov/passport-verify-stub-relying-party


### PR DESCRIPTION
The verify-eidas-metadata-aggregator used to be a private repository. We have now done all the things that we need to make it open source. 

This is the last step to add it to the onboarding guide.