### PR TITLE
Linked to VSP setup on GitHub

### DIFF
--- a/source/pages/arch/arch.rst
+++ b/source/pages/arch/arch.rst
@@ -56,7 +56,7 @@ The main elements in GOV.UK Verify architecture are:
 
 **Verify Service Provider (VSP)**
 
-   `The VSP<https://github.com/alphagov/verify-service-provider#verify-service-provider>`_ is a software tool provided by GOV.UK Verify. It handles communication and authentication between your service and the Verify Hub, converting the Hub's Security Assertion Markup Language (SAML) into JSON (JavaScript Object Notation) and vice versa, and managing much of the security.
+   `The VSP <https://github.com/alphagov/verify-service-provider#verify-service-provider>`_ is a software tool provided by GOV.UK Verify. It handles communication and authentication between your service and the Verify Hub, converting the Hub's Security Assertion Markup Language (SAML) into JSON (JavaScript Object Notation) and vice versa, and managing much of the security.
 
 |
 **Matching Service**

--- a/source/pages/arch/arch.rst
+++ b/source/pages/arch/arch.rst
@@ -56,7 +56,7 @@ The main elements in GOV.UK Verify architecture are:
 
 **Verify Service Provider (VSP)**
 
-   The :ref:`VSP <vsp>` is a software tool provided by GOV.UK Verify. It handles communication and authentication between your service and the Verify Hub, converting the Hub's Security Assertion Markup Language (SAML) into JSON (JavaScript Object Notation) and vice versa, and managing much of the security.
+   `The VSP<https://github.com/alphagov/verify-service-provider#verify-service-provider>`_ is a software tool provided by GOV.UK Verify. It handles communication and authentication between your service and the Verify Hub, converting the Hub's Security Assertion Markup Language (SAML) into JSON (JavaScript Object Notation) and vice versa, and managing much of the security.
 
 |
 **Matching Service**


### PR DESCRIPTION
@RacingHippo suggested linking to information on setting up the VSP from the architecture page.
Docs on setting up the VSP are on GitHub, at the link I've put in.
This change brings the VSP in line with other components on the page which have links to documentation on setting them up. The only difference is that those components have the documentation on setting them up on the tech docs website, not GitHub.