### PR TITLE
Removed redundant acronym explanations

### DIFF
--- a/source/pages/arch/arch.rst
+++ b/source/pages/arch/arch.rst
@@ -75,7 +75,7 @@ The main elements in GOV.UK Verify architecture are:
 
      A :ref:`Local Matching Service <localmatchingservice>` finds a match between a user’s assured identity and a record in the government service's data sources, to allow the user to access the service. Because there’s no unique identifier for UK citizens, locating the record involves matching user information (for example name, address, date of birth) against the service’s records.
 
-**Security Assertion Markup Language (SAML)**
+**SAML**
 
  :ref:`SAML <saml>` is a data format for exchanging information securely. All exchanges between the entities in the GOV.UK Verify federation use SAML but the local matching service managed by the government service usually uses JSON.
 

--- a/source/pages/arch/arch.rst
+++ b/source/pages/arch/arch.rst
@@ -56,7 +56,7 @@ The main elements in GOV.UK Verify architecture are:
 
 **Verify Service Provider (VSP)**
 
-   The :ref:`VSP <vsp>` is a software tool provided by GOV.UK Verify. It handles communication and authentication between your service and the Verify Hub, converting the Hub's Security Assertion Markup Language (SAML) into JSON (JavaScript Object Notation) and vice versa, and managing much of the security.
+   The :ref:`VSP <vsp>` is a software tool provided by GOV.UK Verify. It handles communication and authentication between your service and the Verify Hub, converting the Hub's :ref:`SAML <saml>` into JSON and vice versa, and managing much of the security.
 
 |
 **Matching Service**
@@ -67,7 +67,7 @@ The main elements in GOV.UK Verify architecture are:
 
 **Matching Service Adapter (MSA)**
 
-    The :ref:`Matching Service Adapter <msaUse>` is a software tool provided by GOV.UK Verify. It simplifies communication between your local matching service and the GOV.UK Verify hub. The MSA converts Security Assertion Markup Language (SAML) into JSON (JavaScript Object Notation) and vice versa.
+    The :ref:`Matching Service Adapter <msaUse>` is a software tool provided by GOV.UK Verify. It simplifies communication between your local matching service and the GOV.UK Verify hub. The MSA converts SAML into JSON and vice versa.
 
 |
 

--- a/source/pages/arch/arch.rst
+++ b/source/pages/arch/arch.rst
@@ -67,7 +67,7 @@ The main elements in GOV.UK Verify architecture are:
 
 **Matching Service Adapter (MSA)**
 
-    The :ref:`Matching Service Adapter <msaUse>` is a software tool provided by GOV.UK Verify. It simplifies communication between your local matching service and the GOV.UK Verify hub. The MSA converts SAML into JSON and vice versa.
+    The :ref:`Matching Service Adapter <msaUse>` is a software tool provided by GOV.UK Verify. It simplifies communication between your local matching service and the GOV.UK Verify hub. The MSA converts :ref:`SAML <saml>` into JSON and vice versa.
 
 |
 

--- a/source/pages/msa/msa.rst
+++ b/source/pages/msa/msa.rst
@@ -26,7 +26,7 @@ The MSA is a stateless service. It runs on Java 8 using `Dropwizard <http://www.
 Why does GOV.UK Verify use the Matching Service Adapter?
 --------------------------------------------------------
 
-The hub uses :ref:`Security Assertion Markup Language <saml>` (SAML) as its communication method. Government services usually use JSON (JavaScript Object Notation) for their local matching services. A SAML matching service interface is therefore required.  The MSA converts SAML into JSON and vice versa. It also performs encryption, decryption, and signing of SAML messages. For more information, see the :ref:`diagram showing the SAML message flow <samlWorks>` within the GOV.UK Verify federation.
+The hub uses :ref:`SAML <saml>` as its communication method. Government services usually use JSON (JavaScript Object Notation) for their local matching services. A SAML matching service interface is therefore required.  The MSA converts SAML into JSON and vice versa. It also performs encryption, decryption, and signing of SAML messages. For more information, see the :ref:`diagram showing the SAML message flow <samlWorks>` within the GOV.UK Verify federation.
 
 It can be difficult and expensive to implement a SAML matching service interface. GOV.UK Verify provides the MSA so you can concentrate on the business logic and matching rules for your local matching service.
 

--- a/source/pages/pki/pki.rst
+++ b/source/pages/pki/pki.rst
@@ -14,7 +14,7 @@ Encryption and signing are provided by public-key cryptography. A PKI supports p
 
 The  Identity Assurance Programme (IDAP) runs a PKI to enable secure communication between the entities in the GOV.UK Verify federation, for example, between government services and the GOV.UK Verify hub. For an outline of the technical steps in the onboarding process, see `Stage 4: Build and integration testing <http://alphagov.github.io/identity-assurance-documentation/stage4/Stage4.html>`_ in the onboarding guide.
 
-The entities in the GOV.UK Verify federation communicate with each other using :ref:`Security Assertion Markup Language <saml>` (SAML). Public-key cryptography secures the integrity and privacy of SAML messages sent between the different entities. 
+The entities in the GOV.UK Verify federation communicate with each other using :ref:`SAML <saml>`. Public-key cryptography secures the integrity and privacy of SAML messages sent between the different entities. 
 
 .. rubric:: **What do you need to do?**
 


### PR DESCRIPTION
* Removed acronym explanation for JSON.
* Linked 'SAML' to relevant section in the docs to avoid explaining it every time.