### PR TITLE
Add licence

### DIFF
--- a/LICENCE
+++ b/LICENCE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2017 Crown Copyright (Government Digital Service)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 This is the technical documentation for government services connecting to GOV.UK Verify. It's [open to the public and published using GitHub pages](http://alphagov.github.io/rp-onboarding-tech-docs/).
 
-A general overview of how a government service can connect to Verify is detailed in the the [Onboarding Guide](http://alphagov.github.io/identity-assurance-documentation/#) which is [published and managed separately](https://github.com/alphagov/identity-assurance-documentation). 
+A general overview of how a government service can connect to Verify is detailed in the the [Onboarding Guide](http://alphagov.github.io/identity-assurance-documentation/#) which is [published and managed separately](https://github.com/alphagov/identity-assurance-documentation).
 
-This project uses a documentation tool called [Sphinx](http://sphinx-doc.org/ "sphinx-doc") to convert content written in [reStructuredText](http://docutils.sourceforge.net/rst.html) into HTML. 
+This project uses a documentation tool called [Sphinx](http://sphinx-doc.org/ "sphinx-doc") to convert content written in [reStructuredText](http://docutils.sourceforge.net/rst.html) into HTML.
 
-## Prerequisites 
+## Prerequisites
 
 To build the documentation locally you will need:
 * [Git](https://help.github.com/articles/set-up-git) to manage versions (you may wish to install the [GitHub Desktop](https://desktop.github.com/) GUI)
@@ -18,20 +18,20 @@ To publish changes to the public documentation, you'll need access to Jenkins. C
 
 ## Get a local copy of the files
 
-While it's possible to make changes directly to the content files using GitHub's built-in editing facilities, checking out the source materials to your local machine has the advantage that you can see any warnings generated when the source reStructuredText files are compiled into HTML. It's also the only way to add binary files such as images. 
+While it's possible to make changes directly to the content files using GitHub's built-in editing facilities, checking out the source materials to your local machine has the advantage that you can see any warnings generated when the source reStructuredText files are compiled into HTML. It's also the only way to add binary files such as images.
 
 Clone the repository using the command below.
 ```
 git clone git@github.com:alphagov/rp-onboarding-tech-docs.git
 ```
-...or if you're using the desktop client, pick File->Clone Repository and enter the URL: 
+...or if you're using the desktop client, pick File->Clone Repository and enter the URL:
 ```
 https://github.com/alphagov/rp-onboarding-tech-docs.git
 ```
- 
-## Install Sphinx 
 
-Once you have Python up and running and a copy of the documentation files, you'll need to install the [Pip package manager](http://pip.readthedocs.org/en/stable/installing/), which will take care of fetching and installing the remaining dependencies. 
+## Install Sphinx
+
+Once you have Python up and running and a copy of the documentation files, you'll need to install the [Pip package manager](http://pip.readthedocs.org/en/stable/installing/), which will take care of fetching and installing the remaining dependencies.
 
 Run:
 
@@ -42,7 +42,7 @@ Run:
     python get-pip.py
 ```
 
-Then install the remaining dependencies using: 
+Then install the remaining dependencies using:
 
 ```
     pip install -r requirements.txt
@@ -58,7 +58,7 @@ Then install the remaining dependencies using:
 >   pip install -r requirements.txt
 > ```
 
-### Create a branch 
+### Create a branch
 
 Before editing any files, you should create a git branch so that your changes are bundled together and can later be merged by an editor (see 'pull requests' later):
 
@@ -75,11 +75,11 @@ Where `the-name-of-the-branch` should be a description of the changes you're mak
 
 #### Editing pages
 
-When editing or writing new content, you must follow the [GOV.UK style guide](https://www.gov.uk/guidance/style-guide). 
+When editing or writing new content, you must follow the [GOV.UK style guide](https://www.gov.uk/guidance/style-guide).
 
 The documents must be in [reStructuredText](http://sphinx-doc.org/rest.html#rst-primer) format.
 
-Edit the documentation in the `source` folder - this is the root folder for the reStructuredText documentation, which is used to build the HTML pages. 
+Edit the documentation in the `source` folder - this is the root folder for the reStructuredText documentation, which is used to build the HTML pages.
 
 #### Previewing your work
 
@@ -89,15 +89,15 @@ You can preview any changes before you publish them. From the root folder, execu
 make html
 ```
 
-If there are any incompatible changes, the output will display warning messages to explain what has gone wrong. 
+If there are any incompatible changes, the output will display warning messages to explain what has gone wrong.
 
-You can then open the output file in your browser from the `build/html/` folder to preview your changes. 
+You can then open the output file in your browser from the `build/html/` folder to preview your changes.
 
 #### Committing your changes
 
 Once you're happy with your changes, you'll need to commit them to this repository.
 
-You can do this using the commands below or using the GitHub Desktop Client (by pressing the "Commit to <the-name-of-the-branch>" button at the bottom of the "changes" panel). 
+You can do this using the commands below or using the GitHub Desktop Client (by pressing the "Commit to <the-name-of-the-branch>" button at the bottom of the "changes" panel).
 
 ```
 git add .                                       # adds any new files to your git repo
@@ -105,7 +105,7 @@ git commit -m "<enter change description here>" # creates a new 'commit' which c
 git push -u origin <the-name-of-the-branch>     # pushes your changes to your forked repository
 ```
 
-> Any future changes you make on this branch can be pushed with 
+> Any future changes you make on this branch can be pushed with
 > ```
 > git push
 > ```
@@ -116,7 +116,7 @@ All changes to documentation must be reviewed before publishing.
 
 This is done by issuing a **pull request**, which alerts subscribers to the repository that there is a change to be reviewed and *merged* into the master branch for publication.
 
-1. Go to [the GitHub repository](https://github.com/alphagov/rp-onboarding-tech-docs). 
+1. Go to [the GitHub repository](https://github.com/alphagov/rp-onboarding-tech-docs).
 2. You should see your branch near the top of the page in a box labeled "Your recently pushed branches".
 3. There will be a big green button next to it saying "Compare & pull request". Press that button.
 4. Enter any (optional) comments and press the green "Create pull request" button.
@@ -126,7 +126,7 @@ This is done by issuing a **pull request**, which alerts subscribers to the repo
 
 Once your changes are accepted and merged into the master branch, they are placed in the Jenkins [build pipeline](https://build.ida.digital.cabinet-office.gov.uk/view/rp-onboarding-tech-docs-pipeline/). This triggers a build job which runs automatically and publishes your changes in the live documentation.
 
-Once built, your changes will be visible in the [published documentation](http://alphagov.github.io/rp-onboarding-tech-docs/). 
+Once built, your changes will be visible in the [published documentation](http://alphagov.github.io/rp-onboarding-tech-docs/).
 
 ## Support and raising issues
 
@@ -134,3 +134,13 @@ If you think you have discovered a security issue in this code please email disc
 
 For non-security related bugs and feature requests please raise an issue in the [GitHub issue tracker](https://github.com/alphagov/rp-onboarding-tech-docs/issues).
 
+## Licence
+
+Unless stated otherwise, the codebase is released under [the MIT License][mit].
+This covers both the codebase and any sample code in the documentation.
+
+The documentation is [© Crown copyright][copyright] and available under the terms of the [Open Government 3.0][ogl] licence.
+
+[mit]: LICENCE
+[copyright]: http://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/
+[ogl]: http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/


### PR DESCRIPTION
The PR adds the licence information required for GDS open repos, as [described in the GDS Way](https://gds-way.cloudapps.digital/manuals/licensing.html#copyright-notice):

* MIT License for the codebase
* OGL Licence for the documentation content

The separate `LICENCE` file contains the MIT license.

The `README.md` file now has a `## Licence` section which references `LICENCE` and also links to OGL.


