### PR TITLE
Redirect to new docs website

### DIFF
--- a/source/_templates/layout.html
+++ b/source/_templates/layout.html
@@ -4,6 +4,7 @@
   <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.1/jquery.min.js"></script>
   <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.8.2/moment.js"></script>
   <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/js-cookie/2.0.4/js.cookie.js"></script>
+  <meta http-equiv="refresh" content="0;URL='http://docs.verify.service.gov.uk/'" />
 
   <script>
     (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){


### PR DESCRIPTION
This is to redirect users to the new documentation website once it is released.
The new documentation website will be at `https://docs.verify.service.gov.uk`

When going to any URL in the sphinx/Github pages docs, the user will be automatically sent to the landing page for the new docs website. This landing page will offer direction based on what the user might need to do.

This PR should not be merged until the new docs website is published using the new domain.