### PR TITLE
EID-1016: Make "environment" in the MSA config a required value

### DIFF
--- a/source/pages/matching/matchingserviceadapter.rst
+++ b/source/pages/matching/matchingserviceadapter.rst
@@ -254,7 +254,7 @@ In the field ``metadata:``
 
   * for the production environment, use the provided ``prod_ida_metadata.ts`` file (this is the default setting in the ``prod-config.yml`` file)
 
-10. Set the ``environment`` value to either ``PRODUCTION`` or ``INTEGRATION``. This ensures that the MSA uses the correct ``hub`` and ``idp`` truststores shipped with each release. If you need to override these, for instance for testing in Integration, set both the ``hubTrustStore`` and ``idpTrustStore`` values instead.
+ 10. Set ``environment`` to either ``PRODUCTION`` or ``INTEGRATION``. This ensures that the MSA uses the correct ``hub`` and ``idp`` truststores for each release. If you need to override the default truststores during testing, add ``hubTrustStore`` and ``idpTrustStore`` to the ``metadata`` section.
 
 .. _msaeidas:
 

--- a/source/pages/matching/matchingserviceadapter.rst
+++ b/source/pages/matching/matchingserviceadapter.rst
@@ -254,7 +254,7 @@ In the field ``metadata:``
 
   * for the production environment, use the provided ``prod_ida_metadata.ts`` file (this is the default setting in the ``prod-config.yml`` file)
 
-10. (optional) If you need to override the ``hub`` and ``idp`` truststore path for testing in Integration, uncomment the ``hubTrustStore`` and ``idpTrustStore`` sections in test-config.yml.
+10. Set the ``environment`` value to either ``PRODUCTION`` or ``INTEGRATION``. This ensures that the MSA uses the correct ``hub`` and ``idp`` truststores shipped with each release. If you need to override these, for instance for testing in Integration, set both the ``hubTrustStore`` and ``idpTrustStore`` values instead.
 
 .. _msaeidas:
 


### PR DESCRIPTION
Change the instructions on how to configure the MSA in line with the changes made for EID-1016 ([see the PR](https://github.com/alphagov/verify-matching-service-adapter/pull/102)).

Clarify that the 'environment' value is now required, or the hub and idp truststores need to be specified.