### PR TITLE
Remove auto-redirect to new docs

### DIFF
--- a/source/_templates/layout.html
+++ b/source/_templates/layout.html
@@ -1,34 +1,42 @@
-{% extends "!layout.html" %}
-{% block extrahead %}
-  <link href="{{ pathto("_static/style.css", True) }}" rel="stylesheet" type="text/css">
-  <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.1/jquery.min.js"></script>
-  <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.8.2/moment.js"></script>
-  <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/js-cookie/2.0.4/js.cookie.js"></script>
-  <meta http-equiv="refresh" content="0;URL='http://www.docs.verify.service.gov.uk/'" />
+<!doctype html>
+<html lang="en" class="govuk-template js history flexbox no-flexboxtweener fixedsticky-withoutfixedfixed">
+  <title>GOV.UK Verify technical documentation | Verify</title>
+  <link href="https://design-system.service.gov.uk/stylesheets/main-f6bfcc94697eaee2e00b08e160414707.css" rel="stylesheet">
 
-  <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+  <header class="govuk-header " role="banner" data-module="govuk-header">
+      <div class="govuk-header__container govuk-header__container--full-width">
+        <div class="govuk-header__logo">
+          <a href="http://www.docs.verify.service.gov.uk/" class="govuk-header__link govuk-header__link--homepage">
+            <span class="govuk-header__logotype">
+              <svg role="presentation" focusable="false" class="govuk-header__logotype-crown" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 132 97" height="30" width="36">
+                <path fill="currentColor" fill-rule="evenodd" d="M25 30.2c3.5 1.5 7.7-.2 9.1-3.7 1.5-3.6-.2-7.8-3.9-9.2-3.6-1.4-7.6.3-9.1 3.9-1.4 3.5.3 7.5 3.9 9zM9 39.5c3.6 1.5 7.8-.2 9.2-3.7 1.5-3.6-.2-7.8-3.9-9.1-3.6-1.5-7.6.2-9.1 3.8-1.4 3.5.3 7.5 3.8 9zM4.4 57.2c3.5 1.5 7.7-.2 9.1-3.8 1.5-3.6-.2-7.7-3.9-9.1-3.5-1.5-7.6.3-9.1 3.8-1.4 3.5.3 7.6 3.9 9.1zm38.3-21.4c3.5 1.5 7.7-.2 9.1-3.8 1.5-3.6-.2-7.7-3.9-9.1-3.6-1.5-7.6.3-9.1 3.8-1.3 3.6.4 7.7 3.9 9.1zm64.4-5.6c-3.6 1.5-7.8-.2-9.1-3.7-1.5-3.6.2-7.8 3.8-9.2 3.6-1.4 7.7.3 9.2 3.9 1.3 3.5-.4 7.5-3.9 9zm15.9 9.3c-3.6 1.5-7.7-.2-9.1-3.7-1.5-3.6.2-7.8 3.7-9.1 3.6-1.5 7.7.2 9.2 3.8 1.5 3.5-.3 7.5-3.8 9zm4.7 17.7c-3.6 1.5-7.8-.2-9.2-3.8-1.5-3.6.2-7.7 3.9-9.1 3.6-1.5 7.7.3 9.2 3.8 1.3 3.5-.4 7.6-3.9 9.1zM89.3 35.8c-3.6 1.5-7.8-.2-9.2-3.8-1.4-3.6.2-7.7 3.9-9.1 3.6-1.5 7.7.3 9.2 3.8 1.4 3.6-.3 7.7-3.9 9.1zM69.7 17.7l8.9 4.7V9.3l-8.9 2.8c-.2-.3-.5-.6-.9-.9L72.4 0H59.6l3.5 11.2c-.3.3-.6.5-.9.9l-8.8-2.8v13.1l8.8-4.7c.3.3.6.7.9.9l-5 15.4v.1c-.2.8-.4 1.6-.4 2.4 0 4.1 3.1 7.5 7 8.1h.2c.3 0 .7.1 1 .1.4 0 .7 0 1-.1h.2c4-.6 7.1-4.1 7.1-8.1 0-.8-.1-1.7-.4-2.4V34l-5.1-15.4c.4-.2.7-.6 1-.9zM66 92.8c16.9 0 32.8 1.1 47.1 3.2 4-16.9 8.9-26.7 14-33.5l-9.6-3.4c1 4.9 1.1 7.2 0 10.2-1.5-1.4-3-4.3-4.2-8.7L108.6 76c2.8-2 5-3.2 7.5-3.3-4.4 9.4-10 11.9-13.6 11.2-4.3-.8-6.3-4.6-5.6-7.9 1-4.7 5.7-5.9 8-.5 4.3-8.7-3-11.4-7.6-8.8 7.1-7.2 7.9-13.5 2.1-21.1-8 6.1-8.1 12.3-4.5 20.8-4.7-5.4-12.1-2.5-9.5 6.2 3.4-5.2 7.9-2 7.2 3.1-.6 4.3-6.4 7.8-13.5 7.2-10.3-.9-10.9-8-11.2-13.8 2.5-.5 7.1 1.8 11 7.3L80.2 60c-4.1 4.4-8 5.3-12.3 5.4 1.4-4.4 8-11.6 8-11.6H55.5s6.4 7.2 7.9 11.6c-4.2-.1-8-1-12.3-5.4l1.4 16.4c3.9-5.5 8.5-7.7 10.9-7.3-.3 5.8-.9 12.8-11.1 13.8-7.2.6-12.9-2.9-13.5-7.2-.7-5 3.8-8.3 7.1-3.1 2.7-8.7-4.6-11.6-9.4-6.2 3.7-8.5 3.6-14.7-4.6-20.8-5.8 7.6-5 13.9 2.2 21.1-4.7-2.6-11.9.1-7.7 8.8 2.3-5.5 7.1-4.2 8.1.5.7 3.3-1.3 7.1-5.7 7.9-3.5.7-9-1.8-13.5-11.2 2.5.1 4.7 1.3 7.5 3.3l-4.7-15.4c-1.2 4.4-2.7 7.2-4.3 8.7-1.1-3-.9-5.3 0-10.2l-9.5 3.4c5 6.9 9.9 16.7 14 33.5 14.8-2.1 30.8-3.2 47.7-3.2z"></path>
+                <image src="/assets/images/govuk-logotype-crown.png" xlink:href="" class="govuk-header__logotype-crown-fallback-image" width="36" height="32"></image>
+              </svg>
+              <span class="govuk-header__logotype-text">
+                GOV.UK
+              </span>
+            </span>
+            <span class="govuk-header__product-name">
+              Verify
+            </span>
+          </a>
+        </div>
+      </div>
+    </header>
 
-    ga('create', 'UA-54060634-2', 'auto');
-    ga('send', 'pageview');
+  <div class="govuk-width-container">
+    <main class="govuk-main-wrapper">
 
-  </script>
-  <script type="text/javascript" src="{{ pathto("_static/CookieBanner.js", True) }}"></script>
-  <script>
-    $(function() {new CookieBanner("seen_cookie_message", 28, "ida-cookie-message").launch();});
-  </script>
-{% endblock %}
+      <p class="govuk-body">This page has moved to <kbd><a href="http://www.docs.verify.service.gov.uk/" class="govuk-link">www.docs.verify.service.gov.uk</a></kbd> </p>
 
-{% block extrabody %}
-<div id="ida-cookie-message">
-  <div id="cookie-message-close" style="display:none">
-    <a href="">✖</a>
+      <form action="https://www.google.co.uk/search" method="get" role="search">
+        <input type="hidden" name="as_sitesearch" value="https://www.docs.verify.service.gov.uk">
+        <label class="govuk-label search__label" for="search">Search</label>
+        {% set name, anchor = pagename.split('#') if '#' in pagename else pagename, '' %}
+        {% set name_parts = pagename.split('/') %}
+        <input class="govuk-input govuk-input--width-20 govuk-!-margin-bottom-4" id="search" name="q" type="text" aria-controls="search-results" placeholder="Search" value="{{ name_parts|last }}">
+        <input type="submit" class="govuk-button">
+      </form>
+    </main>
   </div>
-  <div id="ida-cookie-message-body">
-    <p>To help us improve, this site uses <a target="_blank" title="Learn more about how we use cookies (opens in a new window)" href="https://www.signin.service.gov.uk/cookies">cookies</a>.</p>
-  </div>
-</div>
-{% endblock %}
+</html>


### PR DESCRIPTION
The existing redirect made updating existing links in our documentation a bit harder as you couldn't straight away see where they were supposed to be going to.

I've stuck a search box in so that people can maybe still find what they're after.

I don't know exactly how long we've had this in place, but I suspect we can actually just archive the whole repo quite soon.

https://govuk.zendesk.com/agent/tickets/3823725